### PR TITLE
Bump gatsby-source-filesystem to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "gatsby-plugin-offline": "^2.0.16",
     "gatsby-plugin-react-helmet": "^3.0.2",
     "gatsby-plugin-sharp": "^2.0.14",
-    "gatsby-source-filesystem": "^2.0.17",
+    "gatsby-source-filesystem": "^2.0.20",
     "gatsby-source-instagram": "^0.2.4",
     "gatsby-source-medium": "^2.0.4",
     "gatsby-transformer-remark": "^2.2.0",


### PR DESCRIPTION
... in order to fix warning from npm audit