### PR TITLE
Delete cache first in deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "start": "npm run develop",
     "format": "prettier --write \"src/**/*.js\"",
     "test": "echo \"Write tests! -> https://gatsby.app/unit-testing\"",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
+    "deploy": "rm -rf .cache/* && gatsby build --prefix-paths && gh-pages -d public",
+    "dev": "rm -rf .cache/* && gatsby develop"
   },
   "devDependencies": {
     "gh-pages": "^2.0.1",


### PR DESCRIPTION
Cleans the cache before deploying to gh-pages. This ensures that the `pathPrefix` option is picked up by `gatsby-remark-images`, which makes the image urls in markdown pages correct.