### PR TITLE
Remove pathPrefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,6 @@ module.exports = {
     description: `.`,
     author: `@antidecaf`,
   },
-  pathPrefix: "/jobbsb1",
   plugins: [
     `gatsby-plugin-react-helmet`,
     {


### PR DESCRIPTION
Fjerner pathPrefix ettersom siten nå tilsynelatende kjører på eget domene (url-er til bilder o.l. blir feil når prefix/mappenavnet legges til).