### PR TITLE
Øker bredde for å vise tre hele kort, ikke tre og litt av kort fire.

### DIFF
--- a/src/components/layout.less
+++ b/src/components/layout.less
@@ -210,7 +210,8 @@ img {
     display: flex;
 
     .ffe-image-card {
-      width: 290px;
+      width: 320px;
+      max-width: 320px;
     }
 
     .ffe-image-card__image {


### PR DESCRIPTION
![Screenshot from 2019-05-09 10-37-16](https://user-images.githubusercontent.com/399343/57439526-7fdd5680-7246-11e9-8e20-400fc0d21703.png)
