### PR TITLE
Ny Medium-feed basert på RSS

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -60,6 +60,18 @@ module.exports = {
     //   },
     // },
     {
+      resolve: `gatsby-source-rss-feed`,
+      options: {
+        url: `https://medium.com/feed/sparebank1-digital`,
+        name: `sb1digital`,
+        parserOption: {
+          customFields: {
+            item: ['image:url'],
+          },
+        },
+      },
+    },
+    {
       resolve: "gatsby-source-hrmanager",
       options: {
         customerAlias: 'sparebank1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8091,6 +8091,15 @@
         }
       }
     },
+    "gatsby-source-rss-feed": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-source-rss-feed/-/gatsby-source-rss-feed-1.1.1.tgz",
+      "integrity": "sha512-plPlNJl74gQAnfocu6g0wH9bD5P2Radq4ujANhMWoc+fjIhOJAXy3Iq9FYXrZhMG/PrG2aYNPP0DGUzxP3tvCw==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "rss-parser": "^3.6.2"
+      }
+    },
     "gatsby-telemetry": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.0.tgz",
@@ -14594,6 +14603,11 @@
       "resolved": "https://registry.npmjs.org/react-timestamp/-/react-timestamp-5.1.0.tgz",
       "integrity": "sha512-JWiHW3HJAJZvtAi1Th1sqGe1RRflEkz/63Cw6nFQfUIxHQUN3XPsEkQO1TVCLWLMRyCKmSZpGTJp9qs28Ug3FQ=="
     },
+    "react-truncate": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-truncate/-/react-truncate-2.4.0.tgz",
+      "integrity": "sha512-3QW11/COYwi6iPUaunUhl06DW5NJBJD1WkmxW5YxqqUu6kvP+msB3jfoLg8WRbu57JqgebjVW8Lknw6T5/QZdA=="
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -15081,6 +15095,15 @@
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
+      }
+    },
+    "rss-parser": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.7.2.tgz",
+      "integrity": "sha512-kx0VIFelgwBk5qA4n32U6cx40anAU7TwlRXjyxLDFgMlg8/UcJ64x+Hj5oRX1Kjos+OeFGOmnd5YXH5ES+bmzg==",
+      "requires": {
+        "entities": "^1.1.1",
+        "xml2js": "^0.4.19"
       }
     },
     "rsvp": {
@@ -16411,6 +16434,11 @@
       "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
       "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
       "dev": true
+    },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
     },
     "style-loader": {
       "version": "0.21.0",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,16 @@
     "gatsby-source-filesystem": "^2.0.27",
     "gatsby-source-instagram": "^0.5.1",
     "gatsby-source-medium": "^2.0.6",
+    "gatsby-source-rss-feed": "^1.1.1",
     "gatsby-transformer-remark": "^2.3.8",
     "gatsby-transformer-sharp": "^2.1.17",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-helmet": "^5.2.0",
-    "react-timestamp": "^5.1.0"
+    "react-timestamp": "^5.1.0",
+    "react-truncate": "^2.4.0",
+    "striptags": "^3.1.1"
   },
   "license": "MIT",
   "scripts": {

--- a/src/components/layout.less
+++ b/src/components/layout.less
@@ -306,23 +306,37 @@ img {
     margin: 5px 20px 0 5px;
     display: flex;
 
-    .ffe-image-card {
+    .ffe-text-card {
       width: 290px;
-    }
-
-    .ffe-image-card__image {
-      height: 160px;
-    }
-
-    .ffe-image-card__body {
       flex-grow: 1;
       text-align: left;
       display: flex;
       flex-direction: column;
     }
 
+    .ffe-card-component--text {
+      max-height: 242px;
+      overflow: hidden;
+      position: relative;
+
+      &::after {
+        content: "";
+        display: block;
+        width: 100%;
+        height: 75px;
+        position: absolute;
+        bottom: 0;
+        background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+      }
+    }
+
+    .ffe-card-component--title {
+      margin-bottom: 16px;
+    }
+
     .ffe-card-component--subtext {
       margin: auto 0 0 0;
+      padding-top: 8px;
     }
   }
 }

--- a/src/components/rssMedium.js
+++ b/src/components/rssMedium.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { StaticQuery, graphql } from 'gatsby'
+import RssMediumarticles from '../components/rssMediumarticles'
+
+const rssMedium = ({ children }) => (
+  <StaticQuery
+    query={graphql`
+    query {
+        allFeedsb1Digital {
+          edges {
+            node {
+              title
+              link
+              content {
+                encoded
+              }
+              creator
+            }
+          }
+        }
+      }
+    `}
+    render={data => (
+      <>
+          <RssMediumarticles posts={data.allFeedsb1Digital}/>
+      </>
+    )}
+  />
+)
+rssMedium.propTypes = {
+  children: PropTypes.node.isRequired,
+}
+export default rssMedium

--- a/src/components/rssMediumarticles.js
+++ b/src/components/rssMediumarticles.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import classNames from 'classnames';
+import { TextCard } from '@sb1/ffe-cards-react';
+import striptags from 'striptags';
+import Truncate from 'react-truncate';
+
+function next(e) {
+    let elem = document.querySelector('.sb1-mediumfeed--visible');
+    let elemIdSplit = elem.getAttribute('id').split('-');
+    let elemId = parseInt(elemIdSplit[1]);
+    const elemPrefix = '#' + elemIdSplit[0] + '-';
+
+    if (elemId < 9) {
+        let nextElemId = parseInt(elemId + 1);
+        let nextElem = document.querySelector(elemPrefix + nextElemId);
+        let track = document.querySelector('.sb1-mediumfeed .sb1-somefeed__track-inner');
+
+        track.classList.remove('sb1-somefeed__track-inner--' + elemId);
+        track.classList.add('sb1-somefeed__track-inner--' + nextElemId);
+        elem.classList.remove('sb1-mediumfeed--visible');
+        nextElem.classList.add('sb1-mediumfeed--visible');
+    }
+}
+
+function prev(e) {
+    let elem = document.querySelector('.sb1-mediumfeed--visible');
+    let elemIdSplit = elem.getAttribute('id').split('-');
+    let elemId = parseInt(elemIdSplit[1]);
+    const elemPrefix = '#' + elemIdSplit[0] + '-';
+
+    if (elemId > 0) {
+        let nextElemId = parseInt(elemId - 1);
+        let nextElem = document.querySelector(elemPrefix + nextElemId);
+        let track = document.querySelector('.sb1-mediumfeed .sb1-somefeed__track-inner');
+
+        track.classList.remove('sb1-somefeed__track-inner--' + elemId);
+        track.classList.add('sb1-somefeed__track-inner--' + nextElemId);
+        elem.classList.remove('sb1-mediumfeed--visible');
+        nextElem.classList.add('sb1-mediumfeed--visible');
+    }
+}
+
+export default ({posts}) => (
+    <div className='sb1-mediumfeed sb1-somefeed'>
+        <h3 className="ffe-h3">
+            <a href="https://medium.com/sparebank1-digital" className="ffe-link-text ffe-link-text--no-underline" target="_blank" rel="noopener noreferrer">@sparebank1-digital</a> på Medium
+        </h3>
+
+        <div className="sb1-somefeed__track">
+            <div className="sb1-somefeed__track-inner">
+                {
+                    posts.edges.map((item, index) => {
+                        let active = (index === 0);
+
+                        return (
+                            <div
+                                key={ item.node.id }
+                                id={ 'med-' + index }
+                                className={classNames(
+                                    'sb1-mediumfeed__article', {
+                                    'sb1-mediumfeed--visible': active
+                                })
+                            }>
+                                <React.Fragment>
+                                    <TextCard
+                                        element="a"
+                                        href={ item.node.link }
+                                    >
+                                        {({ Title, Subtext, Text }) => (
+                                            <React.Fragment>
+                                                <Title overflowEllipsis={false}>{ item.node.title }</Title>
+                                                <Text>
+                                                    <Truncate lines={10} width={226} ellipsis="...">
+                                                        { striptags(item.node.content.encoded) }
+                                                    </Truncate>
+                                                </Text>
+                                                <Subtext>Av { item.node.creator }</Subtext>
+                                            </React.Fragment>
+                                        )}
+                                    </TextCard>
+                                </React.Fragment>
+                            </div>
+                        )
+                    })
+                }
+            </div>
+        </div>
+
+        <div className="sb1-somefeed__controls">
+            <button
+                onClick={prev}
+                className="ffe-inline-button ffe-inline-button--tertiary"
+            >Forrige</button>
+            <button
+                onClick={next}
+                className="ffe-inline-button ffe-inline-button--tertiary"
+            >Neste</button>
+        </div>
+    </div>
+)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import Layout from '../components/layout'
 import Header from '../components/header'
 import SEO from '../components/seo'
 import Instagram from '../components/instagram';
-// import Medium from '../components/medium';
+import RssMedium from '../components/rssMedium';
 import Jobs from '../components/jobs/jobs'
 // import Img from "gatsby-image"
 
@@ -94,13 +94,13 @@ const IndexPage = (props) => (
         </GridRow>
     </Grid>
 
-    {/* <Grid>
+    <Grid>
         <GridRow topPadding={ true } background="grey-warm">
             <GridCol sm={{ cols: 12 }} md={{ cols: 10, offset: 1 }} center={true}>
-                <Medium />
+                <RssMedium />
             </GridCol>
         </GridRow>
-    </Grid> */}
+    </Grid>
 
     <Grid topPadding={ false }>
         <GridRow topPadding={ true } background="grey-warm">


### PR DESCRIPTION
Gjenoppliver Medium-feeden med RSS som endepunkt i stedet for API-et. Dataene fra RSS er ikke fullt så utførlige, så denne varianten mangler bilder og innfører noen avhengigheter for truncating og vasking av html-tagger. Men bedre enn ingenting!

![image](https://user-images.githubusercontent.com/463847/64564187-45e5a380-d351-11e9-85ed-4db965aaa228.png)
