### PR TITLE
La til stillinger fra Informasjonssikkerhet

### DIFF
--- a/src/components/jobs/jobs.js
+++ b/src/components/jobs/jobs.js
@@ -15,7 +15,7 @@ export default () => (
             }
             filter: {
               Department: {
-                Name: {regex: "/Digitalbankutvikling ansatte/"}
+                Name: {regex: "/Digitalbankutvikling ansatte|Informasjonssikkerhet/"}
               }
             }
           ) {


### PR DESCRIPTION
På Bsides konferansen ønsker vi å vise frem sommerjobber hos Informasjonssikkerhet. Utvidet derfor søket til å inkludere stillinger fra den avdelingen. 
![Screenshot from 2020-03-04 16-27-08](https://user-images.githubusercontent.com/399343/75895340-c9caa500-5e35-11ea-8118-ce490692e3d6.png)
