### PR TITLE
Fjerner argumenter fra api-url

### DIFF
--- a/plugins/gatsby-source-hrmanager/gatsby-node.js
+++ b/plugins/gatsby-source-hrmanager/gatsby-node.js
@@ -34,7 +34,7 @@ exports.sourceNodes = (
   // Join apiOptions with the HRmanager API URL
   // ?incads=1&plainads=1 returns Advertisements {Content}
   //const apiUrl = `https://recruiter-api.hr-manager.net/jobportal.svc/${configOptions.customerAlias}/positionlist/json/`
-  const apiUrl = `https://recruiter-api.hr-manager.net/jobportal.svc/${configOptions.customerAlias}/positionlist/json/?mediaid=4636&take=20`
+  const apiUrl = `https://recruiter-api.hr-manager.net/jobportal.svc/${configOptions.customerAlias}/positionlist/json/`
   
 
   // Gatsby expects sourceNodes to return a promise


### PR DESCRIPTION
Api-et gir ikke lenger noen treff med argumentene `mediaid` og `take`, så fjerner disse fra urlen.

(Det returneres fortsatt ingen resultater ettersom vi ikke har noen stillinger ute fra riktig `Department`, men prøv f.eks å legge til "IT Drift" i filteret for å verifisere at man får resultater fra api.et.)