### PR TITLE
Fikser layout-issues på undersider på mobil

### DIFF
--- a/src/components/fagdag.less
+++ b/src/components/fagdag.less
@@ -70,18 +70,26 @@
         border-right: none;
         border-left: none;
         border-radius: 0;
+        display: inline-block;
+        height: 1.5em;
         color: @ffe-blue-azure;
         border-color: @ffe-blue-azure;
-        font-size: 24px;
-        line-height: 24px;
+        font-size: 18px;
+        line-height: 18px;
         background-color: transparent;
-        margin: 0 @ffe-spacing-md;
+        margin: 0 @ffe-spacing-xs;
         padding: 0 @ffe-spacing-lg 0 @ffe-spacing-xs;
         cursor: pointer;
 
         &:hover {
             color: @ffe-blue-royal;
             border-color: @ffe-blue-royal;
+        }
+
+        @media (min-width: @breakpoint-md) {
+            font-size: 24px;
+            line-height: 24px;
+            margin: 0 @ffe-spacing-md;
         }
     }
 
@@ -157,73 +165,74 @@
     }
 
     //GRID
-    .container{
-        display: grid;
-        grid-template-columns: [first] 1fr [line2] 1fr [line3] 1fr [line4] 1fr [line5] 1fr [line6] 1fr [end];
-        grid-template-rows: [row1-start] auto [row1-end] auto [third-line] auto [forth-line] auto [last-line];
-        grid-column-gap: @ffe-spacing-4xl;
-        grid-row-gap: @ffe-spacing-4xl;
-        align-items: center;
-    }
+    @media (min-width: @breakpoint-md) {
+        .container{
+            display: grid;
+            grid-template-columns: [first] 1fr [line2] 1fr [line3] 1fr [line4] 1fr [line5] 1fr [line6] 1fr [end];
+            grid-template-rows: [row1-start] auto [row1-end] auto [third-line] auto [forth-line] auto [last-line];
+            grid-column-gap: @ffe-spacing-4xl;
+            grid-row-gap: @ffe-spacing-4xl;
+            align-items: center;
+        }
 
-    .paragraph-a {
-        grid-column-start: first;
-        grid-column-end: line4;
-        grid-row-start: row1-start;
-        grid-row-end: 2;
-    }
-    .image-a {
-        grid-column-start: line4;
-        grid-column-end: end;
-        grid-row-start: row1-start;
-        grid-row-end: 2;
-        width: 100%;
-        height: 100%;
-    }
+        .paragraph-a {
+            grid-column-start: first;
+            grid-column-end: line4;
+            grid-row-start: row1-start;
+            grid-row-end: 2;
+        }
+        .image-a {
+            grid-column-start: line4;
+            grid-column-end: end;
+            grid-row-start: row1-start;
+            grid-row-end: 2;
+            width: 100%;
+            height: 100%;
+        }
 
-    .paragraph-b {
-        grid-column-start: 3;
-        grid-column-end: end;
-        grid-row-start: row1-end;
-        grid-row-end: 3;
-    }
-    .image-b {
-        grid-column-start: 1;
-        grid-column-end: 3;
-        grid-row-start: 2;
-        grid-row-end: 3;
-        width: 100%;
-        height: 100%;
-    }
+        .paragraph-b {
+            grid-column-start: 3;
+            grid-column-end: end;
+            grid-row-start: row1-end;
+            grid-row-end: 3;
+        }
+        .image-b {
+            grid-column-start: 1;
+            grid-column-end: 3;
+            grid-row-start: 2;
+            grid-row-end: 3;
+            width: 100%;
+            height: 100%;
+        }
 
-    .paragraph-c {
-        grid-column-start: 1;
-        grid-column-end: line5;
-        grid-row-start: third-line;
-        grid-row-end: 3;
+        .paragraph-c {
+            grid-column-start: 1;
+            grid-column-end: line5;
+            grid-row-start: third-line;
+            grid-row-end: 3;
+        }
+        .image-c {
+            grid-column-start: line5;
+            grid-column-end: end;
+            grid-row-start: third-line;
+            grid-row-end: 3;
+            width: 100%;
+            height: 100%;
+        }
+        
+        .paragraph-d {
+            grid-column-start: 4;
+            grid-column-end: end;
+            grid-row-start: forth-line;
+            grid-row-end: 4;
+        }
+        .image-d {
+            grid-column-start: 1;
+            grid-column-end: 4;
+            grid-row-start: forth-line;
+            grid-row-end: 4;
+            width: 100%;
+            height: 100%;
+        }
     }
-    .image-c {
-        grid-column-start: line5;
-        grid-column-end: end;
-        grid-row-start: third-line;
-        grid-row-end: 3;
-        width: 100%;
-        height: 100%;
-    }
-    
-    .paragraph-d {
-        grid-column-start: 4;
-        grid-column-end: end;
-        grid-row-start: forth-line;
-        grid-row-end: 4;
-    }
-    .image-d {
-        grid-column-start: 1;
-        grid-column-end: 4;
-        grid-row-start: forth-line;
-        grid-row-end: 4;
-        width: 100%;
-        height: 100%;
-    }
-
 }

--- a/src/pages/dettelagervi.js
+++ b/src/pages/dettelagervi.js
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { Link } from 'gatsby'
 import Layout from '../components/layout'
 import Header from '../components/header'
 import { Grid, GridRow, GridCol } from '@sb1/ffe-grid-react'
@@ -88,6 +89,9 @@ const DettelagerviPage = () => {
                         <p>
                             Vi er en gjeng som er glade i å lese, og koser oss med Unicorn Project – men Accelerate er bibelen vår. Vi ønsker å få alle endringer ut i produksjon så fort de er klare. Ingen kø, ingen lager, ingen ventetid. Hos oss går det i små, hyppige releaser. Vi har faktisk over 2000 releaser i året.
                         </p>
+                        <p>
+                            <Link to="/#ansatte">Her kan du bli enda bedre kjent med oss og folka som jobber her.</Link>
+                        </p>
                     </div>
                     }
 
@@ -115,6 +119,9 @@ const DettelagerviPage = () => {
 
                         <p>
                             Vi jobber med samfunnskritiske tjenester som betaling og boliglån, som brukes av hundretusenvis av mennesker, og vi legger til rette for alt fra hverdagslige kjøp på matbutikken til realisering av boligdrømmen. Vi hjelper forbrukere til å gjennomføre oppgaver de i utgangspunktet ikke gleder seg til, til noe overraskende enkelt, oversiktlig og til og med engasjerende. Og vi hjelper bankene til å formidle tips og råd (og produkter) som gir folk bedre oversikt og bedre økonomi.
+                        </p>
+                        <p>
+                            <Link to="/#ansatte">Her kan du bli enda bedre kjent med oss og folka som jobber her.</Link>
                         </p>
                     </div>
                     }


### PR DESCRIPTION
Fjerner layout basert på css-grid fra små skjermer + andre småfikser.

Før/etter:

![sparebank1](https://user-images.githubusercontent.com/463847/81817226-b3735080-952c-11ea-856b-a174544e68d5.jpg)
