### PR TITLE
Litt penere utforming av some-lenker på mobil

### DIFF
--- a/src/components/layout.less
+++ b/src/components/layout.less
@@ -57,9 +57,13 @@ img {
 }
 
 .sb1-smaller-link {
-  display: inline-block;
-  margin-left: @ffe-spacing-sm;
+  display: block;
   font-size: .7em;
+
+  @media (min-width: @breakpoint-md) {
+    display: inline-block;
+    margin-left: @ffe-spacing-sm;
+  }
 }
 
 .sb1-hero {


### PR DESCRIPTION
Fjerner unødvendig margin som skaper ubalanse.

Før:
<img width="319" alt="Screenshot 2020-05-13 at 20 17 50" src="https://user-images.githubusercontent.com/463847/81849604-111c9280-9557-11ea-9759-eb908584bbb0.png">

Etter:
<img width="319" alt="Screenshot 2020-05-13 at 20 18 29" src="https://user-images.githubusercontent.com/463847/81849619-17ab0a00-9557-11ea-9b24-92b7891bc33b.png">
